### PR TITLE
switch to production builds

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,7 +8,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - name: Deploy to VPS
+      - name: Pull latest code
         uses: appleboy/ssh-action@v1
         with:
           host: ${{ secrets.VPS_HOST }}
@@ -19,4 +19,24 @@ jobs:
             cd ~/conquerio
             git checkout production
             git pull origin production
+
+      - name: Build and start backend + db
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.VPS_HOST }}
+          username: ${{ secrets.VPS_USER }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          script: |
+            cd ~/conquerio
             docker compose up --build -d
+
+      - name: Build frontend
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.VPS_HOST }}
+          username: ${{ secrets.VPS_USER }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          script: |
+            cd ~/conquerio/frontend
+            npm install
+            npm run build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ Keep them short and lowercase. Examples:
 ## Running locally
 
 ```
-docker compose up --build
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build
 ```
 
 - Frontend: http://localhost:5173

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,14 @@
+services:
+  backend:
+    environment:
+      ASPNETCORE_ENVIRONMENT: Development
+
+  frontend:
+    build: ./frontend
+    ports:
+      - "5173:5173"
+    volumes:
+      - ./frontend:/app
+      - /app/node_modules
+    depends_on:
+      - backend

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,21 +24,10 @@ services:
       - "8080:8080"
     environment:
       ConnectionStrings__DefaultConnection: "Server=db;Port=3306;Database=${MYSQL_DATABASE};User=${MYSQL_USER};Password=${MYSQL_PASSWORD}"
-      ASPNETCORE_ENVIRONMENT: Development
+      ASPNETCORE_ENVIRONMENT: Production
     depends_on:
       db:
         condition: service_healthy
-
-  frontend:
-    build: ./frontend
-    ports:
-      - "5173:5173"
-    volumes:
-      - ./frontend:/app
-      - /app/node_modules
-    command: npx vite --host 0.0.0.0
-    depends_on:
-      - backend
 
 volumes:
   mysql_data:


### PR DESCRIPTION
## What changed
- Removed frontend container from production docker-compose
- Frontend now builds with `npm run build`, VPS nginx serves static files from `~/conquerio/frontend/dist`
- Backend runs in Production mode instead of Development
- Deploy pipeline split into 3 steps (pull, backend+db, frontend build) for easier debugging
- Added `docker-compose.dev.yml` override for local dev with vite hot reload
- Updated CONTRIBUTING.md with new dev command

## How to run locally
```
docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build
```

closes #14