### PR TITLE
fix prod build pipeline errors

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,5 +38,6 @@ jobs:
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           script: |
             cd ~/conquerio/frontend
+            rm -rf node_modules
             npm install
             npm run build

--- a/frontend/src/game/NetworkClient.ts
+++ b/frontend/src/game/NetworkClient.ts
@@ -37,7 +37,7 @@ export class NetworkClient {
     this.ws?.send(JSON.stringify({ type: "input", dir }));
   }
 
-  onDeath(cb: DeathCallback) {
+  onDeath(cb: (msg: { killedBy: string | null; reason: string }) => void) {
     this.onDeathCb = cb;
   }
 

--- a/frontend/src/game/Renderer.ts
+++ b/frontend/src/game/Renderer.ts
@@ -109,7 +109,7 @@ export class Renderer {
     }
   }
 
-  private drawMinimap(state: GameState, players: Player[], canvasW: number, canvasH: number) {
+  private drawMinimap(state: GameState, players: Player[], canvasW: number, _canvasH: number) {
     const ctx = this.ctx;
     const size = 150;
     const padding = 12;


### PR DESCRIPTION
## Summary
- fix `DeathCallback` type reference in NetworkClient.ts (removed during cleanup but still referenced)
- fix unused `canvasH` parameter in Renderer.ts minimap method
- nuke `node_modules` before `npm install` in deploy pipeline to avoid root-owned permission issues

ref #14