### PR TITLE
add health check endpoint

### DIFF
--- a/backend/Endpoints/HealthEndpoints.cs
+++ b/backend/Endpoints/HealthEndpoints.cs
@@ -1,0 +1,23 @@
+using conquerio.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace conquerio.Endpoints;
+
+public static class HealthEndpoints
+{
+    public static void MapHealthEndpoints(this WebApplication app)
+    {
+        app.MapGet("/api/health", async (AppDbContext db) =>
+        {
+            try
+            {
+                await db.Database.CanConnectAsync();
+                return Results.Ok(new { status = "healthy" });
+            }
+            catch
+            {
+                return Results.StatusCode(503);
+            }
+        });
+    }
+}

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -74,5 +74,6 @@ app.UseAuthorization();
 app.MapAuthEndpoints();
 app.MapGameEndpoints();
 app.MapWebSocketEndpoints();
+app.MapHealthEndpoints();
 
 app.Run();


### PR DESCRIPTION
Closes #19

## Summary
- Add `GET /api/health` endpoint
- Returns `200` with `{"status":"healthy"}` when the DB is reachable
- Returns `503` when the DB connection fails
- For use with UptimeRobot monitoring

## Test plan
- [x] Tested locally - returns `{"status":"healthy"}` with running DB