### PR TITLE
implement territory claiming with flood fill

### DIFF
--- a/backend/Game/GameRoom.cs
+++ b/backend/Game/GameRoom.cs
@@ -44,6 +44,21 @@ public class GameRoom
             Socket = socket
         };
 
+        // claim 3x3 spawn territory
+        for (int ox = -1; ox <= 1; ox++)
+        {
+            for (int oy = -1; oy <= 1; oy++)
+            {
+                int tx = spawnX + ox;
+                int ty = spawnY + oy;
+                if (tx >= 0 && tx < GridWidth && ty >= 0 && ty < GridHeight)
+                {
+                    Grid[tx, ty] = colorId;
+                    _gridDiff.Add(new GridCell { X = tx, Y = ty, C = colorId });
+                }
+            }
+        }
+
         Players[playerId] = player;
         return player;
     }
@@ -72,14 +87,32 @@ public class GameRoom
             if (!p.IsAlive) continue;
 
             var (dx, dy) = GetDelta(p.Direction);
-            p.X += dx;
-            p.Y += dy;
+            int newX = p.X + dx;
+            int newY = p.Y + dy;
 
             // clamp to grid bounds
-            if (p.X < 0) p.X = 0;
-            if (p.X >= GridWidth) p.X = GridWidth - 1;
-            if (p.Y < 0) p.Y = 0;
-            if (p.Y >= GridHeight) p.Y = GridHeight - 1;
+            newX = Math.Clamp(newX, 0, GridWidth - 1);
+            newY = Math.Clamp(newY, 0, GridHeight - 1);
+
+            bool wasOnTerritory = TerritoryResolver.IsOnOwnTerritory(Grid, p.X, p.Y, p.ColorId);
+            bool isOnTerritory = TerritoryResolver.IsOnOwnTerritory(Grid, newX, newY, p.ColorId);
+
+            p.X = newX;
+            p.Y = newY;
+
+            if (isOnTerritory && p.Trail.Count > 0)
+            {
+                // returned to own territory with trail - claim enclosed area
+                ClaimTerritory(p);
+            }
+            else if (!isOnTerritory)
+            {
+                // outside territory - track trail
+                if (p.Trail.Count == 0 || p.Trail[^1] != (newX, newY))
+                {
+                    p.Trail.Add((newX, newY));
+                }
+            }
         }
 
         BroadcastState();
@@ -140,4 +173,18 @@ public class GameRoom
         (a == Direction.Down && b == Direction.Up) ||
         (a == Direction.Left && b == Direction.Right) ||
         (a == Direction.Right && b == Direction.Left);
+
+    private void ClaimTerritory(PlayerState player)
+    {
+        var cellsToClaim = TerritoryResolver.Resolve(Grid, player);
+        foreach (var (x, y) in cellsToClaim)
+        {
+            if (Grid[x, y] != player.ColorId)
+            {
+                Grid[x, y] = player.ColorId;
+                _gridDiff.Add(new GridCell { X = x, Y = y, C = player.ColorId });
+            }
+        }
+        player.Trail.Clear();
+    }
 }

--- a/backend/Game/TerritoryResolver.cs
+++ b/backend/Game/TerritoryResolver.cs
@@ -4,8 +4,99 @@ public static class TerritoryResolver
 {
     public static List<(int X, int Y)> Resolve(byte[,] grid, PlayerState player)
     {
-        // TODO: flood-fill to claim enclosed territory when player
-        // returns to their own territory with an active trail
-        return new List<(int X, int Y)>();
+        var trail = player.Trail;
+        if (trail.Count == 0)
+            return new List<(int X, int Y)>();
+
+        int width = grid.GetLength(0);
+        int height = grid.GetLength(1);
+        byte colorId = player.ColorId;
+
+        // create working grid with trail marked as player territory
+        var working = new byte[width, height];
+        Buffer.BlockCopy(grid, 0, working, 0, grid.Length);
+        foreach (var (x, y) in trail)
+        {
+            working[x, y] = colorId;
+        }
+
+        // flood fill from edges to find all cells reachable from outside
+        var reachable = new bool[width, height];
+        var queue = new Queue<(int X, int Y)>();
+
+        // seed with edge cells that are not player territory
+        for (int x = 0; x < width; x++)
+        {
+            if (working[x, 0] != colorId && !reachable[x, 0])
+            {
+                reachable[x, 0] = true;
+                queue.Enqueue((x, 0));
+            }
+            if (working[x, height - 1] != colorId && !reachable[x, height - 1])
+            {
+                reachable[x, height - 1] = true;
+                queue.Enqueue((x, height - 1));
+            }
+        }
+        for (int y = 1; y < height - 1; y++)
+        {
+            if (working[0, y] != colorId && !reachable[0, y])
+            {
+                reachable[0, y] = true;
+                queue.Enqueue((0, y));
+            }
+            if (working[width - 1, y] != colorId && !reachable[width - 1, y])
+            {
+                reachable[width - 1, y] = true;
+                queue.Enqueue((width - 1, y));
+            }
+        }
+
+        // bfs flood fill
+        int[] dx = { 0, 0, -1, 1 };
+        int[] dy = { -1, 1, 0, 0 };
+
+        while (queue.Count > 0)
+        {
+            var (cx, cy) = queue.Dequeue();
+            for (int i = 0; i < 4; i++)
+            {
+                int nx = cx + dx[i];
+                int ny = cy + dy[i];
+                if (nx >= 0 && nx < width && ny >= 0 && ny < height &&
+                    !reachable[nx, ny] && working[nx, ny] != colorId)
+                {
+                    reachable[nx, ny] = true;
+                    queue.Enqueue((nx, ny));
+                }
+            }
+        }
+
+        // collect enclosed cells (not reachable, not already player territory in original grid)
+        // plus all trail cells
+        var trailSet = new HashSet<(int, int)>(trail);
+        var claimed = new List<(int X, int Y)>();
+
+        for (int x = 0; x < width; x++)
+        {
+            for (int y = 0; y < height; y++)
+            {
+                if (trailSet.Contains((x, y)))
+                {
+                    claimed.Add((x, y));
+                }
+                else if (!reachable[x, y] && grid[x, y] != colorId)
+                {
+                    claimed.Add((x, y));
+                }
+            }
+        }
+
+        return claimed;
+    }
+
+    public static bool IsOnOwnTerritory(byte[,] grid, int x, int y, byte colorId)
+    {
+        return grid[x, y] == colorId;
     }
 }


### PR DESCRIPTION
## Summary
- Implement inverse flood-fill algorithm in TerritoryResolver
- Track player trails when moving outside territory
- Claim enclosed area + trail cells when player returns to territory
- Add 3x3 spawn territory for new players
- Broadcast claimed cells via GridDiff in state messages

Closes #3

## Test plan
- [ ] Join game, move outside spawn territory (trail appears)
- [ ] Return to own territory (trail clears, GridDiff contains claimed cells)
- [ ] Unit tests for TerritoryResolver (Prokop #9)

## Note
Frontend rendering of claimed territory is #6 (Sebastian). This PR implements backend logic only.