### PR TITLE
Add test job to CI pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,7 +5,18 @@ on:
     branches: [production]
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+      - name: Run unit tests
+        run: dotnet test backend/UnitTests/UnitTests.csproj
+
   deploy:
+    needs: test
     runs-on: ubuntu-latest
     steps:
       - name: Pull latest code


### PR DESCRIPTION
## Summary
- Adds a `test` job that runs unit tests on the GitHub Actions runner before deploying
- Deploy job now depends on tests passing (`needs: test`)
- Uses .NET 9 SDK + `dotnet test` on the UnitTests project

## Why
We merged unit tests in #28 but nothing actually runs them before deploying. This makes sure broken code doesn't hit the server.

Closes #29