### PR TITLE
add game room browser

### DIFF
--- a/backend/Endpoints/GameEndpoints.cs
+++ b/backend/Endpoints/GameEndpoints.cs
@@ -1,4 +1,6 @@
-﻿namespace conquerio.Endpoints;
+using conquerio.Game;
+
+namespace conquerio.Endpoints;
 
 public static class GameEndpoints
 {
@@ -11,7 +13,35 @@ public static class GameEndpoints
         // GET /api/stats/{id}
         app.MapGet("/api/stats/{id}", (string id) =>
             Results.Ok("Not implemented yet"));
+
+        app.MapGet("/api/rooms", (GameRoomManager roomManager) =>
+        {
+            var rooms = roomManager.GetAllRooms()
+                .Where(r => r.Players.Count > 0)
+                .Select(r => new
+                {
+                    id = r.RoomId,
+                    name = r.Name,
+                    playerCount = r.Players.Count,
+                    maxPlayers = r.MaxPlayers
+                });
+
+            return Results.Ok(rooms);
+        }).RequireAuthorization();
+
+        app.MapPost("/api/rooms", (GameRoomManager roomManager, CreateRoomRequest? request) =>
+        {
+            var room = roomManager.CreateRoom(request?.Name);
+
+            return Results.Ok(new
+            {
+                id = room.RoomId,
+                name = room.Name,
+                playerCount = 0,
+                maxPlayers = room.MaxPlayers
+            });
+        }).RequireAuthorization();
     }
 }
 
-
+public record CreateRoomRequest(string? Name);

--- a/backend/Endpoints/WebSocketEndpoints.cs
+++ b/backend/Endpoints/WebSocketEndpoints.cs
@@ -52,10 +52,34 @@ public static class WebSocketEndpoints
                 return;
             }
 
-            using var ws = await context.WebSockets.AcceptWebSocketAsync();
+            // figure out which room to join
+            var roomId = context.Request.Query["roomId"].FirstOrDefault();
+            GameRoom room;
 
-            // join a room
-            var room = roomManager.GetOrCreateRoom();
+            if (!string.IsNullOrEmpty(roomId))
+            {
+                var target = roomManager.GetRoom(roomId);
+                if (target == null)
+                {
+                    context.Response.StatusCode = StatusCodes.Status404NotFound;
+                    return;
+                }
+                if (target.IsFull)
+                {
+                    context.Response.StatusCode = StatusCodes.Status409Conflict;
+                    return;
+                }
+                room = target;
+            }
+            else
+            {
+                room = roomManager.GetOrCreateRoom();
+            }
+
+            // cancel cleanup timer if someone joins an empty room
+            roomManager.CancelEmpty(room.RoomId);
+
+            using var ws = await context.WebSockets.AcceptWebSocketAsync();
             var player = room.AddPlayer(userId, user.UserName ?? "unknown", ws);
 
             // send joined message with full grid
@@ -120,6 +144,8 @@ public static class WebSocketEndpoints
             finally
             {
                 room.RemovePlayer(userId);
+                if (room.Players.IsEmpty)
+                    roomManager.MarkEmpty(room.RoomId);
             }
         });
     }

--- a/backend/Game/GameRoom.cs
+++ b/backend/Game/GameRoom.cs
@@ -6,6 +6,7 @@ namespace conquerio.Game;
 public class GameRoom
 {
     public string RoomId { get; }
+    public string Name { get; }
     public int GridWidth { get; } = 200;
     public int GridHeight { get; } = 200;
     public int TickRate { get; } = 20;
@@ -23,9 +24,10 @@ public class GameRoom
     private readonly List<GridCell> _gridDiff = new();
     private readonly Random _rng = new();
 
-    public GameRoom(string roomId)
+    public GameRoom(string roomId, string name)
     {
         RoomId = roomId;
+        Name = name;
         Grid = new byte[GridWidth, GridHeight];
     }
 

--- a/backend/Game/GameRoomManager.cs
+++ b/backend/Game/GameRoomManager.cs
@@ -5,26 +5,80 @@ namespace conquerio.Game;
 public class GameRoomManager
 {
     private readonly ConcurrentDictionary<string, GameRoom> _rooms = new();
+    private readonly ConcurrentDictionary<string, DateTime> _emptyRoomTimestamps = new();
     private int _roomCounter;
+
+    private static readonly TimeSpan EmptyRoomTimeout = TimeSpan.FromSeconds(60);
 
     public GameRoom GetOrCreateRoom()
     {
-        // find a room that isn't full
+        // pick the non-empty room with the most players that isn't full
+        GameRoom? best = null;
         foreach (var room in _rooms.Values)
         {
-            if (!room.IsFull) return room;
+            if (room.IsFull || room.Players.IsEmpty) continue;
+            if (best == null || room.Players.Count > best.Players.Count)
+                best = room;
         }
 
-        // create new room
-        var id = $"room-{Interlocked.Increment(ref _roomCounter)}";
-        var newRoom = new GameRoom(id);
+        return best ?? CreateRoom(null);
+    }
+
+    public GameRoom CreateRoom(string? name)
+    {
+        var counter = Interlocked.Increment(ref _roomCounter);
+        var id = $"room-{counter}";
+        var roomName = name ?? $"Room {counter}";
+        var newRoom = new GameRoom(id, roomName);
         _rooms[id] = newRoom;
+        // start cleanup timer - gets cancelled when someone joins
+        MarkEmpty(id);
         return newRoom;
+    }
+
+    public GameRoom? GetRoom(string roomId)
+    {
+        _rooms.TryGetValue(roomId, out var room);
+        return room;
     }
 
     public IEnumerable<GameRoom> GetAllRooms() => _rooms.Values;
 
-    public void RemoveRoom(string roomId) => _rooms.TryRemove(roomId, out _);
+    public void RemoveRoom(string roomId)
+    {
+        _rooms.TryRemove(roomId, out _);
+        _emptyRoomTimestamps.TryRemove(roomId, out _);
+    }
+
+    public void MarkEmpty(string roomId)
+    {
+        _emptyRoomTimestamps[roomId] = DateTime.UtcNow;
+    }
+
+    public void CancelEmpty(string roomId)
+    {
+        _emptyRoomTimestamps.TryRemove(roomId, out _);
+    }
+
+    public void CleanupEmptyRooms()
+    {
+        var now = DateTime.UtcNow;
+        foreach (var (roomId, emptySince) in _emptyRoomTimestamps)
+        {
+            if (now - emptySince < EmptyRoomTimeout) continue;
+
+            // double check it's still empty before removing
+            if (_rooms.TryGetValue(roomId, out var room) && room.Players.IsEmpty)
+            {
+                RemoveRoom(roomId);
+            }
+            else
+            {
+                // room got players again, cancel the timer
+                _emptyRoomTimestamps.TryRemove(roomId, out _);
+            }
+        }
+    }
 
     public GameRoom? FindRoomForPlayer(string playerId)
     {

--- a/backend/Game/GameTickHostedService.cs
+++ b/backend/Game/GameTickHostedService.cs
@@ -34,6 +34,8 @@ public class GameTickHostedService : BackgroundService
                 }
             }
 
+            _roomManager.CleanupEmptyRooms();
+
             var elapsed = Stopwatch.GetElapsedTime(start);
             var delay = _interval - elapsed;
             if (delay > TimeSpan.Zero)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,13 +1,51 @@
 import { useState } from "react";
 import LoginScreen from "./ui/LoginScreen";
+import RoomBrowser from "./ui/RoomBrowser";
 import GameCanvas from "./game/GameCanvas";
 
-export default function App() {
-  const [token, setToken] = useState<string | null>(null);
+type Screen = "login" | "rooms" | "game";
 
-  if (!token) {
-    return <LoginScreen onLogin={setToken} />;
+export default function App() {
+  const [screen, setScreen] = useState<Screen>("login");
+  const [token, setToken] = useState<string | null>(null);
+  const [roomId, setRoomId] = useState<string | null>(null);
+
+  if (screen === "login" || !token) {
+    return (
+      <LoginScreen
+        onLogin={(t) => {
+          setToken(t);
+          setScreen("rooms");
+        }}
+      />
+    );
   }
 
-  return <GameCanvas token={token} onDisconnect={() => setToken(null)} />;
+  if (screen === "rooms") {
+    return (
+      <RoomBrowser
+        token={token}
+        onJoinRoom={(id) => {
+          setRoomId(id);
+          setScreen("game");
+        }}
+        onQuickPlay={() => {
+          setRoomId(null);
+          setScreen("game");
+        }}
+        onLogout={() => {
+          setToken(null);
+          setScreen("login");
+        }}
+      />
+    );
+  }
+
+  return (
+    <GameCanvas
+      token={token}
+      roomId={roomId ?? undefined}
+      onDisconnect={() => setScreen("rooms")}
+    />
+  );
 }

--- a/frontend/src/api/rooms.ts
+++ b/frontend/src/api/rooms.ts
@@ -1,0 +1,29 @@
+const API = "/api/rooms";
+
+export interface RoomInfo {
+  id: string;
+  name: string;
+  playerCount: number;
+  maxPlayers: number;
+}
+
+export async function getRooms(token: string): Promise<RoomInfo[]> {
+  const res = await fetch(API, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) throw new Error(`failed to fetch rooms: ${res.status}`);
+  return res.json();
+}
+
+export async function createRoom(token: string, name?: string): Promise<RoomInfo> {
+  const res = await fetch(API, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify(name ? { name } : {}),
+  });
+  if (!res.ok) throw new Error(`failed to create room: ${res.status}`);
+  return res.json();
+}

--- a/frontend/src/game/GameCanvas.tsx
+++ b/frontend/src/game/GameCanvas.tsx
@@ -5,10 +5,11 @@ import { InputHandler } from "./InputHandler";
 
 interface Props {
   token: string;
+  roomId?: string;
   onDisconnect: () => void;
 }
 
-export default function GameCanvas({ token, onDisconnect }: Props) {
+export default function GameCanvas({ token, roomId, onDisconnect }: Props) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
 
   useEffect(() => {
@@ -35,15 +36,21 @@ export default function GameCanvas({ token, onDisconnect }: Props) {
       // TODO: show death screen
     });
 
-    network.connect(token);
+    let intentionalDisconnect = false;
+    network.onDisconnect(() => {
+      if (!intentionalDisconnect) onDisconnect();
+    });
+
+    network.connect(token, roomId);
 
     return () => {
+      intentionalDisconnect = true;
       window.removeEventListener("resize", resize);
       input.destroy();
       gameLoop.stop();
       network.disconnect();
     };
-  }, [token, onDisconnect]);
+  }, [token, roomId, onDisconnect]);
 
   return <canvas ref={canvasRef} style={{ display: "block" }} />;
 }

--- a/frontend/src/game/NetworkClient.ts
+++ b/frontend/src/game/NetworkClient.ts
@@ -12,10 +12,13 @@ export class NetworkClient {
   private lastTickTime = 0;
   private onDeathCb: ((msg: { killedBy: string | null; reason: string }) => void) | null = null;
   private onJoinedCb: (() => void) | null = null;
+  private onDisconnectCb: (() => void) | null = null;
 
-  connect(token: string) {
+  connect(token: string, roomId?: string) {
     const proto = location.protocol === "https:" ? "wss:" : "ws:";
-    this.ws = new WebSocket(`${proto}//${location.host}/ws/game?token=${token}`);
+    let url = `${proto}//${location.host}/ws/game?token=${token}`;
+    if (roomId) url += `&roomId=${roomId}`;
+    this.ws = new WebSocket(url);
 
     this.ws.onmessage = (e) => {
       const msg: ServerMessage = JSON.parse(e.data);
@@ -25,6 +28,7 @@ export class NetworkClient {
 
     this.ws.onclose = () => {
       this.ws = null;
+      this.onDisconnectCb?.();
     };
   }
 
@@ -47,6 +51,10 @@ export class NetworkClient {
 
   onJoined(cb: () => void) {
     this.onJoinedCb = cb;
+  }
+
+  onDisconnect(cb: () => void) {
+    this.onDisconnectCb = cb;
   }
 
   getState(): GameState | null {

--- a/frontend/src/ui/RoomBrowser.tsx
+++ b/frontend/src/ui/RoomBrowser.tsx
@@ -1,0 +1,207 @@
+import { useEffect, useState } from "react";
+import { getRooms, createRoom, type RoomInfo } from "../api/rooms";
+
+interface Props {
+  token: string;
+  onJoinRoom: (roomId: string) => void;
+  onQuickPlay: () => void;
+  onLogout: () => void;
+}
+
+export default function RoomBrowser({ token, onJoinRoom, onQuickPlay, onLogout }: Props) {
+  const [rooms, setRooms] = useState<RoomInfo[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [creating, setCreating] = useState(false);
+  const [error, setError] = useState("");
+
+  const fetchRooms = async () => {
+    try {
+      const data = await getRooms(token);
+      setRooms(data);
+      setError("");
+    } catch {
+      setError("failed to load rooms");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchRooms();
+    const interval = setInterval(fetchRooms, 5000);
+    return () => clearInterval(interval);
+  }, []);
+
+  const handleCreate = async () => {
+    setCreating(true);
+    try {
+      const room = await createRoom(token);
+      onJoinRoom(room.id);
+    } catch {
+      setError("failed to create room");
+      setCreating(false);
+    }
+  };
+
+  return (
+    <div style={styles.container}>
+      <h1 style={styles.title}>conquerio</h1>
+
+      <div style={styles.actions}>
+        <button style={styles.primaryButton} onClick={onQuickPlay}>
+          quick play
+        </button>
+        <button style={styles.secondaryButton} onClick={handleCreate} disabled={creating}>
+          {creating ? "..." : "create room"}
+        </button>
+      </div>
+
+      <div style={styles.roomList}>
+        {loading && <div style={styles.muted}>loading rooms...</div>}
+        {!loading && rooms.length === 0 && (
+          <div style={styles.muted}>no active rooms - create one or quick play</div>
+        )}
+        {rooms.map((room) => {
+          const full = room.playerCount >= room.maxPlayers;
+          return (
+            <div key={room.id} style={styles.roomCard}>
+              <div style={styles.roomInfo}>
+                <span style={styles.roomName}>{room.name}</span>
+                <span style={full ? styles.playerCountFull : styles.playerCount}>
+                  {room.playerCount}/{room.maxPlayers}
+                </span>
+              </div>
+              <button
+                style={full ? styles.joinButtonDisabled : styles.joinButton}
+                disabled={full}
+                onClick={() => onJoinRoom(room.id)}
+              >
+                {full ? "full" : "join"}
+              </button>
+            </div>
+          );
+        })}
+      </div>
+
+      {error && <div style={styles.error}>{error}</div>}
+
+      <button style={styles.logoutButton} onClick={onLogout}>
+        logout
+      </button>
+    </div>
+  );
+}
+
+const styles: Record<string, React.CSSProperties> = {
+  container: {
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    justifyContent: "center",
+    minHeight: "100vh",
+    background: "#111",
+    color: "#fff",
+    fontFamily: "monospace",
+    padding: "40px 20px",
+  },
+  title: {
+    fontSize: "48px",
+    marginBottom: "32px",
+    letterSpacing: "4px",
+  },
+  actions: {
+    display: "flex",
+    gap: "12px",
+    marginBottom: "24px",
+  },
+  primaryButton: {
+    padding: "12px 24px",
+    background: "#fff",
+    color: "#111",
+    border: "none",
+    fontSize: "16px",
+    fontFamily: "monospace",
+    cursor: "pointer",
+    fontWeight: "bold",
+  },
+  secondaryButton: {
+    padding: "12px 24px",
+    background: "transparent",
+    color: "#fff",
+    border: "1px solid #333",
+    fontSize: "16px",
+    fontFamily: "monospace",
+    cursor: "pointer",
+  },
+  roomList: {
+    display: "flex",
+    flexDirection: "column",
+    gap: "8px",
+    width: "100%",
+    maxWidth: "400px",
+  },
+  roomCard: {
+    display: "flex",
+    justifyContent: "space-between",
+    alignItems: "center",
+    padding: "12px 16px",
+    background: "#222",
+    border: "1px solid #333",
+  },
+  roomInfo: {
+    display: "flex",
+    flexDirection: "column",
+    gap: "4px",
+  },
+  roomName: {
+    fontSize: "14px",
+    color: "#fff",
+  },
+  playerCount: {
+    fontSize: "12px",
+    color: "#999",
+  },
+  playerCountFull: {
+    fontSize: "12px",
+    color: "#e74c3c",
+  },
+  joinButton: {
+    padding: "6px 16px",
+    background: "#fff",
+    color: "#111",
+    border: "none",
+    fontSize: "13px",
+    fontFamily: "monospace",
+    cursor: "pointer",
+    fontWeight: "bold",
+  },
+  joinButtonDisabled: {
+    padding: "6px 16px",
+    background: "#333",
+    color: "#666",
+    border: "none",
+    fontSize: "13px",
+    fontFamily: "monospace",
+    cursor: "not-allowed",
+  },
+  muted: {
+    color: "#666",
+    fontSize: "13px",
+    textAlign: "center",
+    padding: "20px",
+  },
+  error: {
+    color: "#e74c3c",
+    fontSize: "13px",
+    marginTop: "12px",
+  },
+  logoutButton: {
+    background: "none",
+    border: "none",
+    color: "#666",
+    cursor: "pointer",
+    fontSize: "13px",
+    fontFamily: "monospace",
+    marginTop: "24px",
+  },
+};


### PR DESCRIPTION
closes #32

## Summary
- room browser screen between login and gameplay - players can see active rooms, join one, create their own, or quick play
- backend: `GET /api/rooms` and `POST /api/rooms` endpoints, optional `roomId` query param on websocket endpoint
- quick play joins the busiest non-full room
- empty rooms get cleaned up after 60s with no players
- disconnect sends player back to room browser instead of login (token stays valid)

## Test plan
- [x] login -> room browser shows up instead of auto-joining
- [x] quick play joins the room with most players
- [x] create room -> auto-joins the new room
- [x] join specific room from the list
- [x] full rooms show as disabled in the list
- [x] disconnect (close tab, server drop) -> back to room browser
- [x] room list auto-refreshes every 5 seconds
- [x] empty room disappears from list after ~60s
- [x] created room that nobody joins gets cleaned up