### PR TITLE
feat: improve trail and territory rendering (#6)

### DIFF
--- a/frontend/src/game/Renderer.ts
+++ b/frontend/src/game/Renderer.ts
@@ -1,5 +1,11 @@
 import { Camera } from "./Camera";
-import { getColor, getTerritoryColor, getTrailColor } from "./colors";
+import {
+  getColor,
+  getTerritoryColor,
+  getTerritoryBorderColor,
+  getTrailColor,
+  getTrailStrokeColor,
+} from "./colors";
 import type { Player, GameState } from "./types";
 
 export class Renderer {
@@ -28,6 +34,7 @@ export class Renderer {
   private drawGrid(state: GameState, canvasW: number, canvasH: number) {
     const bounds = this.camera.getVisibleBounds(canvasW, canvasH);
     const cs = this.camera.cellSize;
+    const ctx = this.ctx;
 
     for (let y = Math.max(0, bounds.minY); y < Math.min(state.gridHeight, bounds.maxY); y++) {
       for (let x = Math.max(0, bounds.minX); x < Math.min(state.gridWidth, bounds.maxX); x++) {
@@ -35,8 +42,15 @@ export class Renderer {
         if (colorId === 0) continue;
 
         const { sx, sy } = this.camera.worldToScreen(x, y, canvasW, canvasH);
-        this.ctx.fillStyle = getTerritoryColor(colorId);
-        this.ctx.fillRect(sx, sy, cs, cs);
+
+        // Fill: low-opacity wash for the claimed territory
+        ctx.fillStyle = getTerritoryColor(colorId);
+        ctx.fillRect(sx, sy, cs, cs);
+
+        // Inner 1-px border: slightly higher opacity to give each cell definition
+        ctx.strokeStyle = getTerritoryBorderColor(colorId);
+        ctx.lineWidth = 1;
+        ctx.strokeRect(sx + 0.5, sy + 0.5, cs - 1, cs - 1);
       }
     }
   }
@@ -77,14 +91,24 @@ export class Renderer {
 
   private drawTrails(players: Player[], canvasW: number, canvasH: number) {
     const cs = this.camera.cellSize;
+    const ctx = this.ctx;
 
     for (const p of players) {
       if (p.trail.length === 0) continue;
 
-      this.ctx.fillStyle = getTrailColor(p.colorId);
+      // Fill all trail cells first (single style swap)
+      ctx.fillStyle = getTrailColor(p.colorId);
       for (const [tx, ty] of p.trail) {
         const { sx, sy } = this.camera.worldToScreen(tx, ty, canvasW, canvasH);
-        this.ctx.fillRect(sx, sy, cs, cs);
+        ctx.fillRect(sx, sy, cs, cs);
+      }
+
+      // Crisp 1-px stroke over each trail cell for a sharp, defined look
+      ctx.strokeStyle = getTrailStrokeColor(p.colorId);
+      ctx.lineWidth = 1;
+      for (const [tx, ty] of p.trail) {
+        const { sx, sy } = this.camera.worldToScreen(tx, ty, canvasW, canvasH);
+        ctx.strokeRect(sx + 0.5, sy + 0.5, cs - 1, cs - 1);
       }
     }
   }
@@ -137,6 +161,20 @@ export class Renderer {
           my + y * scaleY,
           Math.ceil(scaleX),
           Math.ceil(scaleY)
+        );
+      }
+    }
+
+    // trail cells on minimap — use a brighter shade so they remain legible
+    for (const p of players) {
+      if (p.trail.length === 0) continue;
+      ctx.fillStyle = getTrailColor(p.colorId);
+      for (const [tx, ty] of p.trail) {
+        ctx.fillRect(
+          mx + tx * scaleX,
+          my + ty * scaleY,
+          Math.ceil(scaleX) + 1,
+          Math.ceil(scaleY) + 1
         );
       }
     }

--- a/frontend/src/game/colors.ts
+++ b/frontend/src/game/colors.ts
@@ -21,12 +21,34 @@ export function getColor(colorId: number): string {
   return COLORS[colorId % COLORS.length] ?? COLORS[1];
 }
 
+/**
+ * Trail fill: solid player colour at 70% opacity so trails are clearly
+ * visible against the background but distinct from the player dot itself.
+ */
 export function getTrailColor(colorId: number): string {
-  const base = getColor(colorId);
-  return base + "88"; // semi-transparent
+  return getColor(colorId) + "b3"; // ~70 % opacity
 }
 
+/**
+ * Trail stroke / outline: full-opacity player colour for a crisp 1-px border
+ * that makes each trail segment feel defined and intentional.
+ */
+export function getTrailStrokeColor(colorId: number): string {
+  return getColor(colorId); // 100 % opacity
+}
+
+/**
+ * Claimed territory fill: 22% opacity — subtle wash so the grid is readable
+ * beneath the action and clearly lower-priority than trails.
+ */
 export function getTerritoryColor(colorId: number): string {
-  const base = getColor(colorId);
-  return base + "44"; // more transparent
+  return getColor(colorId) + "38"; // ~22 % opacity
+}
+
+/**
+ * Claimed territory border tint: 45% opacity used to draw a 1-px inner
+ * outline on territory cells, giving them shape without visual noise.
+ */
+export function getTerritoryBorderColor(colorId: number): string {
+  return getColor(colorId) + "73"; // ~45 % opacity
 }


### PR DESCRIPTION
colors.ts:
- Territory fill: 22% opacity (was 26%) for a more subtle background wash
- Territory border: new getTerritoryBorderColor() at 45% opacity - 1px inner outline gives territory cells definition without noise
- Trail fill: 70% opacity (was 53%) so trails are clearly dominant
- Trail stroke: new getTrailStrokeColor() at 100% opacity - crisp solid 1px outline around every trail segment

Renderer.ts:
- drawGrid: add 1px inner strokeRect using getTerritoryBorderColor per cell
- drawTrails: batch fill all cells then batch stroke at full opacity; offset by 0.5px to land on pixel boundaries for sharp rendering
- drawMinimap: now also renders trail cells alongside territory and player dots