### PR TITLE
feat: wire up death screen and respawn flow (#7)

### DIFF
--- a/frontend/src/game/GameCanvas.tsx
+++ b/frontend/src/game/GameCanvas.tsx
@@ -1,7 +1,8 @@
-import { useRef, useEffect } from "react";
+import { useRef, useEffect, useState, useCallback } from "react";
 import { NetworkClient } from "./NetworkClient";
 import { GameLoop } from "./GameLoop";
 import { InputHandler } from "./InputHandler";
+import DeathScreen from "../ui/DeathScreen";
 
 interface Props {
   token: string;
@@ -9,8 +10,22 @@ interface Props {
   onDisconnect: () => void;
 }
 
+interface DeathInfo {
+  reason: string;
+  killedBy: string | null;
+}
+
 export default function GameCanvas({ token, roomId, onDisconnect }: Props) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [death, setDeath] = useState<DeathInfo | null>(null);
+
+  // Bumping this key tears down the entire effect and reconnects
+  const [sessionKey, setSessionKey] = useState(0);
+
+  const handleRespawn = useCallback(() => {
+    setDeath(null);
+    setSessionKey((k) => k + 1);
+  }, []);
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -32,8 +47,9 @@ export default function GameCanvas({ token, roomId, onDisconnect }: Props) {
       gameLoop.start();
     });
 
-    network.onDeath(() => {
-      // TODO: show death screen
+    network.onDeath((msg) => {
+      gameLoop.stop();
+      setDeath({ reason: msg.reason, killedBy: msg.killedBy });
     });
 
     let intentionalDisconnect = false;
@@ -50,7 +66,18 @@ export default function GameCanvas({ token, roomId, onDisconnect }: Props) {
       gameLoop.stop();
       network.disconnect();
     };
-  }, [token, roomId, onDisconnect]);
+  }, [token, roomId, onDisconnect, sessionKey]);
 
-  return <canvas ref={canvasRef} style={{ display: "block" }} />;
+  return (
+    <div style={{ position: "relative", width: "100vw", height: "100vh", overflow: "hidden" }}>
+      <canvas ref={canvasRef} style={{ display: "block" }} />
+      {death && (
+        <DeathScreen
+          reason={death.reason}
+          killedBy={death.killedBy}
+          onRespawn={handleRespawn}
+        />
+      )}
+    </div>
+  );
 }


### PR DESCRIPTION
- GameCanvas now tracks death state (reason + killedBy) via useState
- On server death message: stop game loop, render DeathScreen overlay
- Respawn button clears death state and bumps a sessionKey, which tears down and recreates the WebSocket/GameLoop/InputHandler effect to reconnect the player to the game