### PR TITLE
fix: send death message to client when player dies

### DIFF
--- a/backend/Game/GameRoom.cs
+++ b/backend/Game/GameRoom.cs
@@ -369,6 +369,13 @@ public class GameRoom
             player.Trail.Clear();
         }
 
+        // send death message to the dying player
+        if (player.Socket.State == System.Net.WebSockets.WebSocketState.Open)
+        {
+            var deathMsg = new DeathMessage { KilledBy = killerId, Reason = cause };
+            _ = MessageSerializer.SendAsync(player.Socket, deathMsg);
+        }
+
         var duration = DateTime.UtcNow - player.StartedAt;
         Log.Information("Player {PlayerId} died in room {RoomId} after {DurationSeconds}s. Cause: {Cause}. Metric: GameDuration",
             player.PlayerId, RoomId, duration.TotalSeconds, cause);


### PR DESCRIPTION
## Summary
- KillPlayer() now sends a DeathMessage to the dying player's WebSocket
- Frontend already handles this message type, just wasn't being sent

Fixes #79