### PR TITLE
fix: update stale unit tests

### DIFF
--- a/backend/UnitTests/DeathAndRespawnTest.cs
+++ b/backend/UnitTests/DeathAndRespawnTest.cs
@@ -8,7 +8,7 @@ public class DeathAndRespawnTest : WsTestBase
     public DeathAndRespawnTest(GameFactory factory) : base(factory) { }
 
     [Fact]
-    public async Task SelfTrailCollision_SendsDeathMessage()
+    public async Task SelfTrailCollision_ClaimsTerritory_WhenConnectedToBase()
     {
         var uid = UniqueId();
         var token = await RegisterAndGetToken($"die_{uid}", $"die_{uid}@test.com", "Pass123!");
@@ -20,10 +20,10 @@ public class DeathAndRespawnTest : WsTestBase
         var joined = await ReceiveMsg(ws);
         var playerId = joined.GetProperty("playerId").GetString()!;
         var player = room.Players[playerId];
+        var initialCells = player.OwnedCells;
 
-        // force player into a self-collision: right 5, down 3, left 3, up 3
-        // after 2 ticks right the player leaves 3x3 spawn territory and builds trail
-        // the up leg crosses the horizontal trail at the starting row
+        // make a loop that connects back to territory
+        // right 5, down 3, left 3, up 3 - this should claim territory not kill
         player.Direction = Direction.Right;
         for (int i = 0; i < 5; i++) room.Tick();
 
@@ -36,8 +36,9 @@ public class DeathAndRespawnTest : WsTestBase
         player.Direction = Direction.Up;
         for (int i = 0; i < 4; i++) room.Tick();
 
-        // player should now have hit its own trail and died
-        Assert.False(player.IsAlive);
+        // player should be alive and have claimed more territory
+        Assert.True(player.IsAlive);
+        Assert.True(player.OwnedCells > initialCells);
     }
 
     [Fact]
@@ -154,7 +155,7 @@ public class DeathAndRespawnTest : WsTestBase
     }
 
     [Fact]
-    public async Task Disconnect_KillsPlayer()
+    public async Task Disconnect_MarksPlayerDisconnected()
     {
         var uid = UniqueId();
         var token = await RegisterAndGetToken($"dkill_{uid}", $"dkill_{uid}@test.com", "Pass123!");
@@ -167,12 +168,13 @@ public class DeathAndRespawnTest : WsTestBase
         var playerId = joined.GetProperty("playerId").GetString()!;
 
         Assert.True(room.Players[playerId].IsAlive);
+        Assert.False(room.Players[playerId].IsDisconnected);
 
         await CloseWs(ws);
-        await WaitUntil(() => !room.Players.ContainsKey(playerId));
+        await WaitUntil(() => room.Players[playerId].IsDisconnected);
 
-        // player is removed after disconnect
-        Assert.False(room.Players.ContainsKey(playerId));
+        // player is marked disconnected (not immediately removed - grace period exists)
+        Assert.True(room.Players[playerId].IsDisconnected);
     }
 
     [Fact]

--- a/backend/UnitTests/JoinGameAndMoveTest.cs
+++ b/backend/UnitTests/JoinGameAndMoveTest.cs
@@ -21,8 +21,8 @@ public class JoinGameAndMoveTest : WsTestBase
         Assert.True(joined.GetProperty("gridHeight").GetInt32() > 0);
         Assert.True(joined.GetProperty("tickRate").GetInt32() > 0);
         Assert.False(string.IsNullOrEmpty(joined.GetProperty("playerId").GetString()));
-        // byte[] Grid serializes as base64 string
-        Assert.False(string.IsNullOrEmpty(joined.GetProperty("grid").GetString()));
+        // byte[] RleGrid serializes as base64 string
+        Assert.False(string.IsNullOrEmpty(joined.GetProperty("rleGrid").GetString()));
 
         await CloseWs(ws);
     }

--- a/backend/UnitTests/WebSocketGameFlowTest.cs
+++ b/backend/UnitTests/WebSocketGameFlowTest.cs
@@ -163,7 +163,7 @@ public abstract class WsTestBase : IClassFixture<GameFactory>
             await ws.CloseAsync(WebSocketCloseStatus.NormalClosure, "done", CancellationToken.None);
     }
 
-    protected static async Task WaitUntil(Func<bool> condition, int timeoutMs = 2000, int pollMs = 20)
+    protected static async Task WaitUntil(Func<bool> condition, int timeoutMs = 5000, int pollMs = 50)
     {
         var deadline = DateTime.UtcNow.AddMilliseconds(timeoutMs);
         while (!condition() && DateTime.UtcNow < deadline)

--- a/backend/UnitTests/WsDisconnectTest.cs
+++ b/backend/UnitTests/WsDisconnectTest.cs
@@ -8,7 +8,7 @@ public class WsDisconnectTest : WsTestBase
     public WsDisconnectTest(GameFactory factory) : base(factory) { }
 
     [Fact]
-    public async Task Disconnect_PlayerRemovedFromRoom()
+    public async Task Disconnect_PlayerMarkedDisconnected()
     {
         var uid = UniqueId();
         var token = await RegisterAndGetToken($"disc_{uid}", $"disc_{uid}@test.com", "Pass123!");
@@ -18,12 +18,15 @@ public class WsDisconnectTest : WsTestBase
         var playerId = joined.GetProperty("playerId").GetString()!;
 
         var manager = Factory.Services.GetRequiredService<GameRoomManager>();
-        Assert.NotNull(manager.FindRoomForPlayer(playerId));
+        var room = manager.FindRoomForPlayer(playerId);
+        Assert.NotNull(room);
+        Assert.False(room!.Players[playerId].IsDisconnected);
 
         await CloseWs(ws);
 
-        await WaitUntil(() => manager.FindRoomForPlayer(playerId) == null);
+        // player gets marked disconnected (not removed - there's a grace period)
+        await WaitUntil(() => room.Players[playerId].IsDisconnected);
 
-        Assert.Null(manager.FindRoomForPlayer(playerId));
+        Assert.True(room.Players[playerId].IsDisconnected);
     }
 }


### PR DESCRIPTION
## Summary
- `JoinedMessage` test: `grid` -> `rleGrid`
- `SelfTrailCollision` test: renamed, now verifies territory claim instead of death
- Disconnect tests: check `IsDisconnected` flag instead of player removal (grace period exists)
- Increased `WaitUntil` timeout from 2s to 5s

All 107 tests pass locally.

Fixes #85