### PR TITLE
fix: grid sync for new players joining ongoing game

### DIFF
--- a/frontend/src/game/NetworkClient.ts
+++ b/frontend/src/game/NetworkClient.ts
@@ -110,15 +110,19 @@ export class NetworkClient {
     this.gridHeight = msg.gridHeight;
     this.tickRate = msg.tickRate;
 
-    // Decode RLE grid
+    // Decode base64 RLE grid
+    const binaryStr = atob(msg.rleGrid);
+    const rleBytes = new Uint8Array(binaryStr.length);
+    for (let i = 0; i < binaryStr.length; i++) {
+      rleBytes[i] = binaryStr.charCodeAt(i);
+    }
+
+    // Decode RLE to full grid
     this.grid = new Uint8Array(this.gridWidth * this.gridHeight);
     let offset = 0;
-    for (let i = 0; i < msg.rleGrid.length; i += 2) {
-      const count = msg.rleGrid[i];
-      const value = msg.rleGrid[i + 1];
-      // Backend bug: count might be 0 for the first run if the first cell is different from the initial lastValue (0)
-      // but in GameRoom.cs:291 count starts at 0 and is incremented.
-      // We should handle count=0 just in case
+    for (let i = 0; i < rleBytes.length; i += 2) {
+      const count = rleBytes[i];
+      const value = rleBytes[i + 1];
       for (let j = 0; j < count; j++) {
         if (offset < this.grid.length) {
           this.grid[offset++] = value;

--- a/frontend/src/game/types.ts
+++ b/frontend/src/game/types.ts
@@ -33,7 +33,7 @@ export interface JoinedMessage {
   gridWidth: number;
   gridHeight: number;
   tickRate: number;
-  rleGrid: number[];
+  rleGrid: string; // base64 encoded byte array
 }
 
 export interface StateMessage {


### PR DESCRIPTION
## Summary
- rleGrid from backend is base64 encoded (byte[] in .NET)
- frontend now properly decodes base64 before RLE decompression
- new players joining see existing claimed territory

Fixes #87