### PR TITLE
Fix heading structure across UI screens (#114)

### DIFF
--- a/frontend/src/ui/Leaderboard.tsx
+++ b/frontend/src/ui/Leaderboard.tsx
@@ -122,8 +122,8 @@ export default function Leaderboard({ networkClient }: Props) {
     if (rows.length === 0) return null;
 
     return (
-        <div style={styles.container} role={"region"} aria-label={"Leaderboard"}>
-            <div style={styles.header}>Leaderboard</div>
+        <div style={styles.container} role={"region"} aria-labelledby={"leaderboard-heading"}>
+            <h2 id={"leaderboard-heading"} style={styles.header}>leaderboard</h2>
             {rows.slice(0, DISPLAY_LIMIT).map((row) => {
                 const isMe = row.colorId === myColorId;
                 return (

--- a/frontend/src/ui/LoginScreen.tsx
+++ b/frontend/src/ui/LoginScreen.tsx
@@ -58,6 +58,7 @@ export default function LoginScreen({ onLogin }: Props) {
   return (
     <div style={styles.container}>
       <h1 style={styles.title}>conquerio</h1>
+      <h2 style={styles.subtitle}>{isRegister ? "create account" : "log in"}</h2>
       <form onSubmit={handleSubmit} style={styles.form}>
         <input
           type="text"
@@ -123,8 +124,15 @@ const styles: Record<string, React.CSSProperties> = {
   },
   title: {
     fontSize: "48px",
-    marginBottom: "40px",
+    marginBottom: "8px",
     letterSpacing: "4px",
+  },
+  subtitle: {
+    fontSize: "16px",
+    marginBottom: "32px",
+    color: "#aaa",
+    letterSpacing: "2px",
+    fontWeight: "normal",
   },
   form: {
     display: "flex",

--- a/frontend/src/ui/ProfilePage.tsx
+++ b/frontend/src/ui/ProfilePage.tsx
@@ -35,6 +35,8 @@ export default function ProfilePage({ userId, onBack }: Props) {
                 {!stats && !error && <p style={styles.muted}>loading...</p>}
 
                 {stats && (
+                    <>
+                    <h2 style={styles.statsHeading}>stats</h2>
                     <div style={styles.grid}>
                         <StatRow label="elo" value={stats.elo} />
                         <StatRow label="games" value={stats.totalGames} />
@@ -46,6 +48,7 @@ export default function ProfilePage({ userId, onBack }: Props) {
                             value={`${stats.bestTerritoryPct.toFixed(1)}%`}
                         />
                     </div>
+                    </>
                 )}
 
                 <button style={styles.backButton} onClick={onBack}>
@@ -87,6 +90,14 @@ const styles: Record<string, React.CSSProperties> = {
         marginBottom: "32px",
         letterSpacing: "2px",
         fontWeight: "bold",
+    },
+    statsHeading: {
+        fontSize: "12px",
+        color: "#666",
+        letterSpacing: "2px",
+        textTransform: "uppercase",
+        marginBottom: "12px",
+        fontWeight: "normal",
     },
     grid: {
         display: "flex",

--- a/frontend/src/ui/RoomBrowser.tsx
+++ b/frontend/src/ui/RoomBrowser.tsx
@@ -59,6 +59,7 @@ export default function RoomBrowser({ token, onJoinRoom, onQuickPlay, onProfile,
         </button>
       </div>
 
+        <h2 style={styles.sectionHeading}>active rooms</h2>
         <div style={styles.roomList} role="list" aria-label="Available rooms">
         {loading && <div style={styles.muted}>loading rooms...</div>}
         {!loading && rooms.length === 0 && (
@@ -149,6 +150,15 @@ const styles: Record<string, React.CSSProperties> = {
     fontSize: "16px",
     fontFamily: "monospace",
     cursor: "pointer",
+  },
+  sectionHeading: {
+    fontSize: "12px",
+    color: "#666",
+    letterSpacing: "2px",
+    textTransform: "uppercase",
+    marginBottom: "8px",
+    alignSelf: "flex-start",
+    fontWeight: "normal",
   },
   roomList: {
     display: "flex",


### PR DESCRIPTION
- LoginScreen: add <h2> for login/register form context
- RoomBrowser: add <h2> section heading for the rooms list
- ProfilePage: add <h2> section heading for the stats grid
- Leaderboard: change <div> to <h2> with id for proper aria-labelledby