### PR TITLE
Fix mobile playability

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,7 +2,46 @@
 
 ---
 
-## [2026-03-13]
+## [2026-03-22]
+
+### Se8o — Mobile playability fix (branch: feature/fix-mobile-playability)
+
+**Findings from testing on iOS (iPhone, Safari) and Android (Chrome):**
+
+- **[iOS/Android] Joystick blocked entire game view** — the virtual joystick zone was
+  positioned at `left: 50%, bottom: 50%`, placing it squarely in the center of the screen,
+  completely obscuring the player's view. Fixed: moved to bottom-left (`left: 20px`).
+
+- **[iOS/Android] No way to pause or access the menu** — on desktop, `Escape` opens the pause
+  menu; there is no keyboard on touch devices so this was inaccessible. Fixed: added a
+  hamburger (≡) pause button to the touch overlay, anchored at top-center between the
+  leaderboard and minimap.
+
+- **[iOS/Android] Keyboard shortcut labels ("Space", "Shift") shown in the ability HUD** —
+  the canvas-rendered ability boxes display the keyboard binding ("Space", "Shift") as text
+  in the top-left of each icon. Meaningless on mobile and visually confusing. Fixed: the
+  Renderer now skips drawing the keybind text when `isTouchDevice` is true.
+
+- **[iOS] Pinch-to-zoom and double-tap zoom** — Safari allows the user to zoom the page,
+  breaking the canvas layout. Fixed: updated viewport meta tag to
+  `maximum-scale=1.0, user-scalable=no` and added `viewport-fit=cover` for devices with
+  notch/home indicator.
+
+- **[iOS/Android] Scroll/pull-to-refresh on canvas touch** — dragging the game on mobile
+  could trigger browser scroll or pull-to-refresh. Fixed: added `touchAction: "none"` to
+  the `<canvas>` element and all interactive touch overlay elements.
+
+- **[iOS] Home indicator overlap** — bottom controls (joystick, ability buttons) were
+  rendered over the iOS home indicator at the very bottom edge. Fixed: used
+  `env(safe-area-inset-bottom, 0px)` in CSS calc for bottom positioning.
+
+- **[iOS/Android] Ability buttons had no icons** — the touch overlay buttons showed plain
+  "BOOST"/"SHIELD" text instead of ability artwork. Fixed: buttons now render the ability
+  `.webp` icons for visual clarity.
+
+---
+
+
 
 ### lukas.hrehor
 - show killer username instead of UUID on death screen

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,7 +2,10 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
+    <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta name="description" content="Conquerio: A fast-paced multiplayer territory conquest game. Outmaneuver opponents, claim the map, and rise to the top of the leaderboard!" />
     <meta property="og:title" content="Conquerio - Multiplayer Territory Conquest" />
     <meta property="og:description" content="A fast-paced multiplayer territory conquest game. Outmaneuver opponents, claim the map, and rise to the top of the leaderboard!" />

--- a/frontend/src/game/GameCanvas.tsx
+++ b/frontend/src/game/GameCanvas.tsx
@@ -32,11 +32,7 @@ export default function GameCanvas({ token, roomId, onDisconnect, onProfile }: P
   const [paused, setPaused] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
   const [networkClient, setNetworkClient] = useState<NetworkClient | null>(null);
-  const [isTouchDevice, setIsTouchDevice] = useState(false);
-
-  useEffect(() => {
-    setIsTouchDevice("ontouchstart" in window || navigator.maxTouchPoints > 0);
-  }, []);
+  const [isTouchDevice] = useState(() => "ontouchstart" in window || navigator.maxTouchPoints > 0);
 
   // keep game loop and input in sync when settings change
   useEffect(() => {
@@ -90,7 +86,7 @@ export default function GameCanvas({ token, roomId, onDisconnect, onProfile }: P
     window.addEventListener("resize", resize);
 
     const network = new NetworkClient();
-    const gameLoop = new GameLoop(canvas, network, settings);
+    const gameLoop = new GameLoop(canvas, network, settings, isTouchDevice);
     gameLoopRef.current = gameLoop;
     const input = new InputHandler(network, settings);
     inputHandlerRef.current = input;
@@ -135,7 +131,7 @@ export default function GameCanvas({ token, roomId, onDisconnect, onProfile }: P
     <div style={{ position: "relative", width: "100vw", height: "100vh", overflow: "hidden" }}>
       <canvas
         ref={canvasRef}
-        style={{ display: "block" }}
+        style={{ display: "block", touchAction: "none" }}
         role="img"
         aria-label="Conquerio game arena where players compete for territory"
       />
@@ -146,7 +142,7 @@ export default function GameCanvas({ token, roomId, onDisconnect, onProfile }: P
         <KillFeed networkClient={networkClient} />
       )}
       {networkClient && isTouchDevice && !spectate && !paused && (
-        <TouchControls networkClient={networkClient} />
+        <TouchControls networkClient={networkClient} onPause={() => setPaused(true)} />
       )}
       {paused && !spectate && !showSettings && (
         <PauseMenu

--- a/frontend/src/game/GameLoop.ts
+++ b/frontend/src/game/GameLoop.ts
@@ -14,9 +14,9 @@ export class GameLoop {
   private cameraInitialized = false;
   private spectateTargetId: string | null = null;
 
-  constructor(canvas: HTMLCanvasElement, private network: NetworkClient, settings: GameSettings) {
+  constructor(canvas: HTMLCanvasElement, private network: NetworkClient, settings: GameSettings, isTouchDevice = false) {
     this.camera = new Camera();
-    this.renderer = new Renderer(canvas, this.camera, settings);
+    this.renderer = new Renderer(canvas, this.camera, settings, isTouchDevice);
     this.interpolator = new StateInterpolator(network);
   }
 

--- a/frontend/src/game/Renderer.ts
+++ b/frontend/src/game/Renderer.ts
@@ -16,12 +16,14 @@ export class Renderer {
   private boostImg: HTMLImageElement;
   private shieldImg: HTMLImageElement;
   private settings: GameSettings;
+  private isTouchDevice: boolean;
 
-  constructor(canvas: HTMLCanvasElement, camera: Camera, initialSettings: GameSettings) {
+  constructor(canvas: HTMLCanvasElement, camera: Camera, initialSettings: GameSettings, isTouchDevice = false) {
     this.canvas = canvas;
     this.ctx = canvas.getContext("2d")!;
     this.camera = camera;
     this.settings = initialSettings;
+    this.isTouchDevice = isTouchDevice;
 
     this.boostImg = new Image();
     this.boostImg.src = "/img/boost.webp";
@@ -287,7 +289,7 @@ export class Renderer {
       ctx.font = "bold 12px monospace";
       ctx.textAlign = "left";
       ctx.textBaseline = "alphabetic";
-      ctx.fillText(keybind, x + 4, y + 14);
+      if (!this.isTouchDevice) ctx.fillText(keybind, x + 4, y + 14);
 
       ctx.font = "12px monospace";
       ctx.fillStyle = isActive ? "#00ffcc" : "#aaa";

--- a/frontend/src/ui/TouchControls.tsx
+++ b/frontend/src/ui/TouchControls.tsx
@@ -5,9 +5,10 @@ import {Direction} from "../game/types";
 
 interface Props {
   networkClient: NetworkClient;
+  onPause: () => void;
 }
 
-export default function TouchControls({ networkClient }: Props) {
+export default function TouchControls({ networkClient, onPause }: Props) {
   const joystickRef = useRef<HTMLDivElement>(null);
   const lastDirRef = useRef<Direction | null>(null);
 
@@ -17,9 +18,9 @@ export default function TouchControls({ networkClient }: Props) {
     const manager = nipplejs.create({
       zone: joystickRef.current,
       mode: "static",
-        position: {left: "50%", bottom: "50%"},
+      position: { left: "50%", bottom: "50%" },
       color: "white",
-      size: 100,
+      size: 120,
     });
 
     manager.on("move", (_, data) => {
@@ -47,32 +48,54 @@ export default function TouchControls({ networkClient }: Props) {
     };
   }, [networkClient]);
 
-  const handleAbility = (ability: string) => {
+  const handleAbility = (e: React.PointerEvent, ability: string) => {
+    e.preventDefault();
     networkClient.sendAbility(ability);
   };
 
   return (
     <div style={styles.container}>
+      {/* Joystick — bottom-left */}
       <div ref={joystickRef} style={styles.joystickZone} />
+
+      {/* Ability buttons — bottom-right */}
       <div style={styles.buttonZone}>
-        <button
-          style={styles.abilityBtn}
-          onPointerDown={() => handleAbility("BOOST")}
-          aria-label="Activate Boost"
-        >
-          BOOST
-        </button>
-        <button
-          style={styles.abilityBtn}
-          onPointerDown={() => handleAbility("SHIELD")}
-          aria-label="Activate Shield"
-        >
-          SHIELD
-        </button>
+        <div style={styles.abilityItem}>
+          <button
+            style={styles.abilityBtn}
+            onPointerDown={(e) => handleAbility(e, "BOOST")}
+            aria-label="Activate Boost"
+          >
+            <img src="/img/boost.webp" alt="" style={styles.abilityIcon} draggable={false} />
+          </button>
+          <span style={styles.abilityLabel}>Boost</span>
+        </div>
+        <div style={styles.abilityItem}>
+          <button
+            style={styles.abilityBtn}
+            onPointerDown={(e) => handleAbility(e, "SHIELD")}
+            aria-label="Activate Shield"
+          >
+            <img src="/img/shield.webp" alt="" style={styles.abilityIcon} draggable={false} />
+          </button>
+          <span style={styles.abilityLabel}>Shield</span>
+        </div>
       </div>
+
+      {/* Pause / menu button — top-center */}
+      <button
+        style={styles.pauseBtn}
+        onPointerDown={(e) => { e.preventDefault(); onPause(); }}
+        aria-label="Open menu"
+      >
+        &#9776;
+      </button>
     </div>
   );
 }
+
+const SAFE_BOTTOM = "calc(40px + env(safe-area-inset-bottom, 0px))";
+const SAFE_TOP = "calc(16px + env(safe-area-inset-top, 0px))";
 
 const styles: Record<string, React.CSSProperties> = {
   container: {
@@ -83,37 +106,76 @@ const styles: Record<string, React.CSSProperties> = {
   },
   joystickZone: {
     position: "absolute",
-      left: "50%",
-      bottom: "50%",
-    width: "200px",
-    height: "200px",
-      transform: "translate(-50%, 50%)",
+    left: "20px",
+    bottom: SAFE_BOTTOM,
+    width: "160px",
+    height: "160px",
     pointerEvents: "auto",
+    touchAction: "none",
   },
   buttonZone: {
     position: "absolute",
     right: "20px",
-    bottom: "40px",
+    bottom: SAFE_BOTTOM,
+    display: "flex",
+    flexDirection: "row",
+    gap: "16px",
+    pointerEvents: "auto",
+    alignItems: "flex-end",
+  },
+  abilityItem: {
     display: "flex",
     flexDirection: "column",
-    gap: "20px",
-    pointerEvents: "auto",
+    alignItems: "center",
+    gap: "4px",
   },
   abilityBtn: {
-    width: "80px",
-    height: "80px",
-    borderRadius: "50%",
-    border: "2px solid rgba(255, 255, 255, 0.5)",
-    background: "rgba(0, 0, 0, 0.5)",
-    color: "#fff",
-    fontSize: "12px",
-    fontWeight: "bold",
-    fontFamily: "monospace",
+    width: "72px",
+    height: "72px",
+    borderRadius: "12px",
+    border: "2px solid rgba(255, 255, 255, 0.4)",
+    background: "rgba(0, 0, 0, 0.6)",
     cursor: "pointer",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    padding: "6px",
+    userSelect: "none",
+    WebkitTapHighlightColor: "transparent",
+    touchAction: "none",
+  },
+  abilityIcon: {
+    width: "100%",
+    height: "100%",
+    objectFit: "contain",
+    userSelect: "none",
+  },
+  abilityLabel: {
+    color: "#aaa",
+    fontSize: "11px",
+    fontFamily: "monospace",
+    userSelect: "none",
+  },
+  pauseBtn: {
+    position: "absolute",
+    top: SAFE_TOP,
+    left: "50%",
+    transform: "translateX(-50%)",
+    width: "44px",
+    height: "44px",
+    border: "1px solid rgba(255,255,255,0.3)",
+    borderRadius: "8px",
+    background: "rgba(0,0,0,0.5)",
+    color: "#fff",
+    fontSize: "20px",
+    lineHeight: "1",
+    cursor: "pointer",
+    pointerEvents: "auto",
     display: "flex",
     alignItems: "center",
     justifyContent: "center",
     userSelect: "none",
     WebkitTapHighlightColor: "transparent",
+    touchAction: "none",
   },
 };


### PR DESCRIPTION
- viewport: prevent user zoom, add viewport-fit=cover for safe areas
- canvas: add touch-action:none to prevent scroll/zoom on drag
- GameCanvas: sync isTouchDevice detection, pass to GameLoop/Renderer
- Renderer: skip keyboard keybind label in ability HUD on touch devices
- TouchControls: move joystick from center-screen to bottom-left
- TouchControls: add hamburger pause button at top-center
- TouchControls: replace text BOOST/SHIELD buttons with icon buttons
- TouchControls: apply env(safe-area-inset-bottom) for iOS home indicator
- docs: document iOS and Android testing findings in CHANGELOG