### PR TITLE
end game when player fills the entire map

### DIFF
--- a/backend/Endpoints/WebSocketEndpoints.cs
+++ b/backend/Endpoints/WebSocketEndpoints.cs
@@ -116,7 +116,14 @@ public static class WebSocketEndpoints
                 }
             }
 
+            void OnPlayerWon(PlayerWonEvent evt)
+            {
+                if (evt.WinnerId != userId) return;
+                _ = PersistWinStatsAsync(scopeFactory, logger, evt);
+            }
+
             room.PlayerDied += OnPlayerDied;
+            room.PlayerWon += OnPlayerWon;
 
             // send joined message with full grid
             await MessageSerializer.SendAsync(ws, new JoinedMessage
@@ -181,6 +188,7 @@ public static class WebSocketEndpoints
             {
                 room.MarkDisconnected(userId);
                 room.PlayerDied -= OnPlayerDied;
+                room.PlayerWon -= OnPlayerWon;
 
                 deathEvents.Writer.TryComplete();
                 try
@@ -207,6 +215,54 @@ public static class WebSocketEndpoints
         .WithTags("Game")
         .WithSummary("WebSocket game connection")
         .WithDescription("Connect to the game server via WebSocket. Requires a valid JWT token in the 'token' query parameter and an optional 'roomId'.");
+    }
+
+    private static async Task PersistWinStatsAsync(
+        IServiceScopeFactory scopeFactory,
+        ILogger logger,
+        PlayerWonEvent evt)
+    {
+        using var scope = scopeFactory.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+        var entry = await db.Leaderboard.FirstOrDefaultAsync(lb => lb.UserId == evt.WinnerId);
+        int newElo = (entry?.Elo ?? 1000) + 100;
+
+        try
+        {
+            db.GameRuns.Add(new GameRun
+            {
+                UserId = evt.WinnerId,
+                Kills = evt.Kills,
+                MaxTerritoryPct = evt.MaxTerritoryPct,
+                DeathCause = "won",
+                StartedAt = evt.StartedAtUtc,
+                UpdatedAt = DateTime.UtcNow
+            });
+            await db.SaveChangesAsync();
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to save game run for winner {WinnerId}", evt.WinnerId);
+        }
+
+        try
+        {
+            await UpsertPlayerStatsAsync(db, evt.WinnerId, evt.Kills, evt.MaxTerritoryPct, newElo, isDeath: false);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to upsert player stats for winner {WinnerId}", evt.WinnerId);
+        }
+
+        try
+        {
+            await UpsertLeaderboardAsync(db, evt.WinnerId, evt.MaxTerritoryPct, newElo);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to upsert leaderboard for winner {WinnerId}", evt.WinnerId);
+        }
     }
 
     private static async Task PersistDeathStatsAsync(

--- a/backend/Game/GameRoom.cs
+++ b/backend/Game/GameRoom.cs
@@ -21,8 +21,10 @@ public class GameRoom
 
     /// <summary>Fired on the tick thread whenever a player is killed.</summary>
     public event Action<PlayerDeathEvent>? PlayerDied;
+    public event Action<PlayerWonEvent>? PlayerWon;
 
     private long _tick;
+    private bool _gameEnded;
     private byte _nextColorId = 1;
     private readonly List<GridCell> _gridDiff = new();
     private readonly Random _rng = new();
@@ -34,7 +36,7 @@ public class GameRoom
         Grid = new byte[GridWidth, GridHeight];
     }
 
-    public bool IsFull => Players.Values.Count(p => p.IsAlive) >= MaxPlayers;
+    public bool IsFull => _gameEnded || Players.Values.Count(p => p.IsAlive) >= MaxPlayers;
 
     public PlayerState AddPlayer(string playerId, string username, System.Net.WebSockets.WebSocket socket)
     {
@@ -107,6 +109,7 @@ public class GameRoom
 
     public void Tick()
     {
+        if (_gameEnded) return;
         _tick++;
         _gridDiff.Clear();
 
@@ -505,6 +508,45 @@ public class GameRoom
                 player.Kills++;
                 KillPlayer(other, player.PlayerId, "encircled");
             }
+        }
+
+        // check if the player filled the entire map
+        if (player.OwnedCells >= TotalCells)
+            EndGame(player);
+    }
+
+    private void EndGame(PlayerState winner)
+    {
+        _gameEnded = true;
+
+        var winMsg = new WinMessage { WinnerName = winner.Username };
+        foreach (var p in Players.Values)
+        {
+            if (p.Socket.State == System.Net.WebSockets.WebSocketState.Open)
+                _ = MessageSerializer.SendAsync(p.Socket, winMsg);
+        }
+
+        foreach (var other in Players.Values)
+        {
+            if (!other.IsAlive || other.PlayerId == winner.PlayerId) continue;
+            KillPlayer(other, null, "game_over");
+        }
+
+        Log.Information("Player {PlayerId} won room {RoomId} by filling the map.", winner.PlayerId, RoomId);
+
+        var evt = new PlayerWonEvent(
+            WinnerId: winner.PlayerId,
+            Kills: winner.Kills,
+            MaxTerritoryPct: winner.MaxTerritoryPct,
+            StartedAtUtc: winner.StartedAt);
+
+        var handlers = PlayerWon;
+        if (handlers is null) return;
+
+        foreach (var d in handlers.GetInvocationList())
+        {
+            try { ((Action<PlayerWonEvent>)d)(evt); }
+            catch { }
         }
     }
 

--- a/backend/Game/Messages/ServerMessage.cs
+++ b/backend/Game/Messages/ServerMessage.cs
@@ -93,3 +93,11 @@ public class ErrorMessage
 
     public required string Msg { get; set; }
 }
+
+public class WinMessage
+{
+    [JsonPropertyName("type")]
+    public string Type => "win";
+
+    public required string WinnerName { get; set; }
+}

--- a/backend/Game/PlayerWonEvent.cs
+++ b/backend/Game/PlayerWonEvent.cs
@@ -1,0 +1,7 @@
+namespace conquerio.Game;
+
+public record PlayerWonEvent(
+    string WinnerId,
+    int Kills,
+    float MaxTerritoryPct,
+    DateTime StartedAtUtc);

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -10,5 +10,7 @@ services:
     volumes:
       - ./frontend:/app
       - /app/node_modules
+    environment:
+      BACKEND_ORIGIN: http://backend:8080
     depends_on:
       - backend

--- a/frontend/src/game/GameCanvas.tsx
+++ b/frontend/src/game/GameCanvas.tsx
@@ -9,6 +9,7 @@ import PauseMenu from "../ui/PauseMenu";
 import SettingsMenu from "../ui/SettingsMenu";
 import { useSettings } from "../ui/SettingsContext";
 import TouchControls from "../ui/TouchControls";
+import WinScreen from "../ui/WinScreen";
 
 interface Props {
   token: string;
@@ -22,12 +23,18 @@ interface SpectateInfo {
   killedBy: string | null;
 }
 
+interface WinInfo {
+  winnerName: string;
+  isLocalWinner: boolean;
+}
+
 export default function GameCanvas({ token, roomId, onDisconnect, onProfile }: Props) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const gameLoopRef = useRef<GameLoop | null>(null);
   const inputHandlerRef = useRef<InputHandler | null>(null);
   const { settings } = useSettings();
   const [spectate, setSpectate] = useState<SpectateInfo | null>(null);
+  const [win, setWin] = useState<WinInfo | null>(null);
   const [spectatedPlayerId, setSpectatedPlayerId] = useState<string | null>(null);
   const [paused, setPaused] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
@@ -57,6 +64,7 @@ export default function GameCanvas({ token, roomId, onDisconnect, onProfile }: P
   const handleRespawn = useCallback(() => {
     setSpectate(null);
     setSpectatedPlayerId(null);
+    setWin(null);
     setSessionKey((k) => k + 1);
   }, []);
 
@@ -108,6 +116,14 @@ export default function GameCanvas({ token, roomId, onDisconnect, onProfile }: P
       }
     });
 
+    network.onWin((msg) => {
+      const state = network.getState();
+      const isLocalWinner = state?.players.find(
+        (p) => p.id === state.myPlayerId
+      )?.username === msg.winnerName;
+      setWin({ winnerName: msg.winnerName, isLocalWinner });
+    });
+
     let intentionalDisconnect = false;
     network.onDisconnect(() => {
       if (!intentionalDisconnect) onDisconnect();
@@ -155,7 +171,15 @@ export default function GameCanvas({ token, roomId, onDisconnect, onProfile }: P
       {showSettings && (
         <SettingsMenu onBack={() => setShowSettings(false)} />
       )}
-      {spectate && networkClient && (
+      {win && (
+        <WinScreen
+          winnerName={win.winnerName}
+          isLocalWinner={win.isLocalWinner}
+          onPlay={handleRespawn}
+          onProfile={onProfile}
+        />
+      )}
+      {spectate && !win && networkClient && (
         <SpectateOverlay
           networkClient={networkClient}
           killedBy={spectate.killedBy}
@@ -166,6 +190,7 @@ export default function GameCanvas({ token, roomId, onDisconnect, onProfile }: P
           onProfile={onProfile}
         />
       )}
+
     </div>
   );
 }

--- a/frontend/src/game/NetworkClient.ts
+++ b/frontend/src/game/NetworkClient.ts
@@ -1,4 +1,4 @@
-import type { Direction, GameState, JoinedMessage, KillFeedMessage, ServerMessage, StateMessage } from "./types";
+import type { Direction, GameState, JoinedMessage, KillFeedMessage, ServerMessage, StateMessage, WinMessage } from "./types";
 
 export class NetworkClient {
   private ws: WebSocket | null = null;
@@ -15,6 +15,7 @@ export class NetworkClient {
   private onJoinedCb: (() => void) | null = null;
   private onDisconnectCb: (() => void) | null = null;
   private onStateUpdateCb: ((state: import("./types").GameState) => void) | null = null;
+  private onWinCb: ((msg: WinMessage) => void) | null = null;
 
   connect(token: string, roomId?: string) {
     const proto = location.protocol === "https:" ? "wss:" : "ws:";
@@ -63,6 +64,10 @@ export class NetworkClient {
     this.onDisconnectCb = cb;
   }
 
+  onWin(cb: (msg: WinMessage) => void) {
+    this.onWinCb = cb;
+  }
+
   onStateUpdate(cb: (state: import("./types").GameState) => void) {
     this.onStateUpdateCb = cb;
   }
@@ -108,6 +113,9 @@ export class NetworkClient {
         break;
       case "kill_feed":
         this.onKillFeedCb?.(msg);
+        break;
+      case "win":
+        this.onWinCb?.(msg);
         break;
     }
   }

--- a/frontend/src/game/Renderer.ts
+++ b/frontend/src/game/Renderer.ts
@@ -38,7 +38,7 @@ export class Renderer {
   render(state: GameState, interpolatedPlayers: Player[]) {
     const abilities = state.players.find(x => x.id == state.myPlayerId)?.abilities;
 
-    const { width, height } = this.canvas;
+    const { width, height } = this.ctx.canvas;
     const ctx = this.ctx;
 
     ctx.fillStyle = "#111";

--- a/frontend/src/game/types.ts
+++ b/frontend/src/game/types.ts
@@ -64,4 +64,9 @@ export interface KillFeedMessage {
   reason: string;
 }
 
-export type ServerMessage = JoinedMessage | StateMessage | DeathMessage | KillFeedMessage | { type: "pong"; t: number } | { type: "error"; msg: string };
+export interface WinMessage {
+  type: "win";
+  winnerName: string;
+}
+
+export type ServerMessage = JoinedMessage | StateMessage | DeathMessage | KillFeedMessage | WinMessage | { type: "pong"; t: number } | { type: "error"; msg: string };

--- a/frontend/src/ui/WinScreen.tsx
+++ b/frontend/src/ui/WinScreen.tsx
@@ -1,0 +1,77 @@
+interface Props {
+  winnerName: string;
+  isLocalWinner: boolean;
+  onPlay: () => void;
+  onProfile?: () => void;
+}
+
+export default function WinScreen({ winnerName, isLocalWinner, onPlay, onProfile }: Props) {
+  return (
+    <div style={styles.overlay} role="dialog" aria-modal aria-labelledby="win-title">
+      <div style={styles.box}>
+        <h2 id="win-title" style={styles.title}>
+          {isLocalWinner ? "you won!" : `${winnerName} won`}
+        </h2>
+        <p style={styles.sub}>
+          {isLocalWinner ? "you filled the entire map" : "they filled the entire map"}
+        </p>
+        <button onClick={onPlay} style={styles.button}>
+          play again
+        </button>
+        {onProfile && (
+          <button onClick={onProfile} style={styles.statsLink}>
+            my stats
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+const styles: Record<string, React.CSSProperties> = {
+  overlay: {
+    position: "fixed",
+    inset: 0,
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    background: "rgba(0,0,0,0.7)",
+    zIndex: 10,
+  },
+  box: {
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    textAlign: "center",
+    color: "#fff",
+    fontFamily: "monospace",
+  },
+  title: {
+    fontSize: "36px",
+    marginBottom: "12px",
+  },
+  sub: {
+    color: "#999",
+    marginBottom: "24px",
+  },
+  button: {
+    padding: "12px 32px",
+    background: "#fff",
+    color: "#111",
+    border: "none",
+    fontSize: "16px",
+    fontFamily: "monospace",
+    cursor: "pointer",
+    fontWeight: "bold",
+  },
+  statsLink: {
+    display: "block",
+    background: "none",
+    border: "none",
+    color: "#666",
+    cursor: "pointer",
+    fontSize: "13px",
+    fontFamily: "monospace",
+    marginTop: "12px",
+  },
+};


### PR DESCRIPTION
closes #121

when a player claims 100% of the grid, the game now ends instead of soft-locking.

- backend: `EndGame()` fires on full map fill, sends `win` message to all players, kills others, stops the tick loop and blocks new joins
- frontend: new `WinScreen` shown to winner ("you won!") and others ("X won"), reconnects on "play again"
- also fixes `BACKEND_ORIGIN` in `docker-compose.dev.yml` (was hardcoded to a local IP) and `this.canvas` undefined bug in `Renderer.ts`