### PR TITLE
add lazy loading for heavy ui components

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,10 +1,11 @@
-import { useState } from "react";
+import { useState, lazy, Suspense } from "react";
 import LoginScreen from "./ui/LoginScreen";
-import RoomBrowser from "./ui/RoomBrowser";
-import GameCanvas from "./game/GameCanvas";
-import ProfilePage from "./ui/ProfilePage";
 import { getUserIdFromToken } from "./api/stats";
 import { SettingsProvider } from "./ui/SettingsContext";
+
+const RoomBrowser = lazy(() => import("./ui/RoomBrowser"));
+const GameCanvas = lazy(() => import("./game/GameCanvas"));
+const ProfilePage = lazy(() => import("./ui/ProfilePage"));
 
 type Screen = "login" | "rooms" | "game" | "profile";
 
@@ -78,7 +79,9 @@ export default function App() {
 
   return (
     <SettingsProvider>
-      {content()}
+      <Suspense fallback={null}>
+        {content()}
+      </Suspense>
     </SettingsProvider>
   );
 }

--- a/frontend/src/game/Renderer.ts
+++ b/frontend/src/game/Renderer.ts
@@ -11,7 +11,6 @@ import type { GameSettings } from "../ui/SettingsContext";
 
 export class Renderer {
   private ctx: CanvasRenderingContext2D;
-  private canvas: HTMLCanvasElement;
   private camera: Camera;
   private boostImg: HTMLImageElement;
   private shieldImg: HTMLImageElement;
@@ -19,7 +18,6 @@ export class Renderer {
   private isTouchDevice: boolean;
 
   constructor(canvas: HTMLCanvasElement, camera: Camera, initialSettings: GameSettings, isTouchDevice = false) {
-    this.canvas = canvas;
     this.ctx = canvas.getContext("2d")!;
     this.camera = camera;
     this.settings = initialSettings;


### PR DESCRIPTION
closes #141

RoomBrowser, GameCanvas, and ProfilePage are now lazy loaded with React.lazy() + Suspense. LoginScreen stays eager since it loads first.

Also removes unused private `canvas` field in Renderer.ts that was breaking the build (tsc was failing with noUnusedLocals).