### PR TITLE
add playwright e2e tests

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "nipplejs": "^0.10.2",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests",
+  timeout: 30_000,
+  retries: 1,
+  use: {
+    baseURL: "http://localhost:5173",
+    trace: "on-first-retry",
+  },
+  projects: [
+    { name: "chromium", use: { ...devices["Desktop Chrome"] } },
+    { name: "firefox", use: { ...devices["Desktop Firefox"] } },
+    { name: "mobile", use: { ...devices["Pixel 5"] } },
+  ],
+});

--- a/frontend/tests/auth.spec.ts
+++ b/frontend/tests/auth.spec.ts
@@ -1,0 +1,101 @@
+import { test, expect } from "@playwright/test";
+
+// unique username per run to avoid conflicts
+const uid = () => `t${Date.now()}${Math.floor(Math.random() * 1000)}`;
+
+test.describe("login screen", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+  });
+
+  test("shows login form on load", async ({ page }) => {
+    await expect(page.getByRole("heading", { name: "conquerio" })).toBeVisible();
+    await expect(page.getByPlaceholder("username")).toBeVisible();
+    await expect(page.getByPlaceholder("password")).toBeVisible();
+    await expect(page.getByRole("button", { name: "play" })).toBeVisible();
+  });
+
+  test("toggle to register form shows email field", async ({ page }) => {
+    await page.getByText("no account? register").click();
+    await expect(page.getByPlaceholder("email")).toBeVisible();
+    await expect(page.getByRole("button", { name: "register" })).toBeVisible();
+  });
+
+  test("toggle back to login hides email field", async ({ page }) => {
+    await page.getByText("no account? register").click();
+    await page.getByText("have an account? login").click();
+    await expect(page.getByPlaceholder("email")).not.toBeVisible();
+    await expect(page.getByRole("button", { name: "play" })).toBeVisible();
+  });
+});
+
+test.describe("registration validation", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+    await page.getByText("no account? register").click();
+  });
+
+  test("password too short", async ({ page }) => {
+    await page.getByPlaceholder("username").fill("someuser");
+    await page.getByPlaceholder("email").fill("x@test.com");
+    await page.getByPlaceholder("password").fill("ab1");
+    await page.getByRole("button", { name: "register" }).click();
+    await expect(page.getByText("Password must be at least 6 characters")).toBeVisible();
+  });
+
+  test("password missing digit", async ({ page }) => {
+    await page.getByPlaceholder("username").fill("someuser");
+    await page.getByPlaceholder("email").fill("x@test.com");
+    await page.getByPlaceholder("password").fill("abcdef");
+    await page.getByRole("button", { name: "register" }).click();
+    await expect(page.getByText("Password must contain at least one digit")).toBeVisible();
+  });
+
+  test("password missing lowercase", async ({ page }) => {
+    await page.getByPlaceholder("username").fill("someuser");
+    await page.getByPlaceholder("email").fill("x@test.com");
+    await page.getByPlaceholder("password").fill("ABCDEF1");
+    await page.getByRole("button", { name: "register" }).click();
+    await expect(page.getByText("Password must contain at least one lowercase letter")).toBeVisible();
+  });
+});
+
+test.describe("auth flow", () => {
+  test("login with wrong password shows error", async ({ page }) => {
+    await page.goto("/");
+    await page.getByPlaceholder("username").fill("definitlynotauser99999");
+    await page.getByPlaceholder("password").fill("wrongpass1");
+    await page.getByRole("button", { name: "play" }).click();
+    await expect(page.getByText(/wrong username or password/i)).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("register then auto-login lands on room browser", async ({ page }) => {
+    const user = uid();
+    await page.goto("/");
+    await page.getByText("no account? register").click();
+    await page.getByPlaceholder("username").fill(user);
+    await page.getByPlaceholder("email").fill(`${user}@test.com`);
+    await page.getByPlaceholder("password").fill("testpass1");
+    await page.getByRole("button", { name: "register" }).click();
+    await expect(page.getByRole("button", { name: "quick play" })).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("login with existing user lands on room browser", async ({ page }) => {
+    // register first
+    const user = uid();
+    await page.goto("/");
+    await page.getByText("no account? register").click();
+    await page.getByPlaceholder("username").fill(user);
+    await page.getByPlaceholder("email").fill(`${user}@test.com`);
+    await page.getByPlaceholder("password").fill("testpass1");
+    await page.getByRole("button", { name: "register" }).click();
+    await expect(page.getByRole("button", { name: "quick play" })).toBeVisible({ timeout: 10_000 });
+
+    // logout and log back in
+    await page.getByRole("button", { name: "logout" }).click();
+    await page.getByPlaceholder("username").fill(user);
+    await page.getByPlaceholder("password").fill("testpass1");
+    await page.getByRole("button", { name: "play" }).click();
+    await expect(page.getByRole("button", { name: "quick play" })).toBeVisible({ timeout: 10_000 });
+  });
+});

--- a/frontend/tests/game.spec.ts
+++ b/frontend/tests/game.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect, type Page } from "@playwright/test";
+
+const uid = () => `t${Date.now()}${Math.floor(Math.random() * 1000)}`;
+
+async function registerAndLogin(page: Page) {
+  const user = uid();
+  await page.goto("/");
+  await page.getByText("no account? register").click();
+  await page.getByPlaceholder("username").fill(user);
+  await page.getByPlaceholder("email").fill(`${user}@test.com`);
+  await page.getByPlaceholder("password").fill("testpass1");
+  await page.getByRole("button", { name: "register" }).click();
+  await expect(page.getByRole("button", { name: "quick play" })).toBeVisible({ timeout: 10_000 });
+}
+
+test.describe("game connection", () => {
+  test("quick play loads game canvas", async ({ page }) => {
+    await registerAndLogin(page);
+    await page.getByRole("button", { name: "quick play" }).click();
+    await expect(page.locator("canvas")).toBeVisible({ timeout: 15_000 });
+  });
+
+  test("disconnect returns to room browser", async ({ page }) => {
+    await registerAndLogin(page);
+    await page.getByRole("button", { name: "quick play" }).click();
+    await expect(page.locator("canvas")).toBeVisible({ timeout: 15_000 });
+
+    // open pause menu and disconnect
+    await page.keyboard.press("Escape");
+    await expect(page.getByRole("heading", { name: "menu" })).toBeVisible({ timeout: 5_000 });
+    await page.getByRole("button", { name: "disconnect" }).click();
+    await expect(page.getByRole("button", { name: "quick play" })).toBeVisible({ timeout: 10_000 });
+  });
+});

--- a/frontend/tests/rooms.spec.ts
+++ b/frontend/tests/rooms.spec.ts
@@ -1,0 +1,62 @@
+import { test, expect, type Page } from "@playwright/test";
+
+const uid = () => `t${Date.now()}${Math.floor(Math.random() * 1000)}`;
+
+async function registerAndLogin(page: Page) {
+  const user = uid();
+  await page.goto("/");
+  await page.getByText("no account? register").click();
+  await page.getByPlaceholder("username").fill(user);
+  await page.getByPlaceholder("email").fill(`${user}@test.com`);
+  await page.getByPlaceholder("password").fill("testpass1");
+  await page.getByRole("button", { name: "register" }).click();
+  await expect(page.getByRole("button", { name: "quick play" })).toBeVisible({ timeout: 10_000 });
+}
+
+test.describe("room browser", () => {
+  test("shows main actions after login", async ({ page }) => {
+    await registerAndLogin(page);
+    await expect(page.getByRole("button", { name: "quick play" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "create room" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "logout" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "my profile" })).toBeVisible();
+  });
+
+  test("create room modal opens and closes", async ({ page }) => {
+    await registerAndLogin(page);
+    await page.getByRole("button", { name: "create room" }).click();
+    await expect(page.getByRole("heading", { name: "create room" })).toBeVisible();
+    await page.getByRole("button", { name: "✕" }).click();
+    await expect(page.getByRole("heading", { name: "create room" })).not.toBeVisible();
+  });
+
+  test("private room requires join code", async ({ page }) => {
+    await registerAndLogin(page);
+    await page.getByRole("button", { name: "create room" }).click();
+    await page.getByRole("button", { name: "private" }).click();
+    // submit without join code
+    await page.getByRole("button", { name: "create room" }).last().click();
+    await expect(page.getByText("join code required for private rooms")).toBeVisible();
+  });
+
+  test("logout returns to login screen", async ({ page }) => {
+    await registerAndLogin(page);
+    await page.getByRole("button", { name: "logout" }).click();
+    await expect(page.getByPlaceholder("username")).toBeVisible();
+    await expect(page.getByRole("button", { name: "play" })).toBeVisible();
+  });
+
+  test("my profile navigates to profile page", async ({ page }) => {
+    await registerAndLogin(page);
+    await page.getByRole("button", { name: "my profile" }).click();
+    await expect(page.getByRole("heading", { name: "stats" })).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("settings menu opens and closes", async ({ page }) => {
+    await registerAndLogin(page);
+    await page.getByRole("button", { name: "settings" }).click();
+    await expect(page.getByRole("heading", { name: "settings" })).toBeVisible();
+    await page.getByRole("button", { name: "back" }).click();
+    await expect(page.getByRole("heading", { name: "settings" })).not.toBeVisible();
+  });
+});


### PR DESCRIPTION
closes #145

Adds playwright config and test suites:
- `tests/auth.spec.ts` - login/register flows, client-side validation (short pw, no digit, no lowercase), wrong credentials error
- `tests/rooms.spec.ts` - room browser navigation, create room modal, private room validation, logout, profile, settings
- `tests/game.spec.ts` - quick play connects and canvas loads, disconnect returns to room browser

Runs on chromium, firefox, and mobile (Pixel 5) - ticks cross-browser and mobile testing boxes too.

Run with: `npm run test:e2e` (requires full stack at localhost:5173)