### PR TITLE
add k6 load test for concurrent players

### DIFF
--- a/docs/load-test/README.md
+++ b/docs/load-test/README.md
@@ -1,0 +1,37 @@
+# Load Test
+
+Uses [k6](https://k6.io) to simulate concurrent players hitting the API and WebSocket.
+
+## What it tests
+
+- `/api/health` - basic availability
+- `/api/rooms` - room list under load
+- `/api/leaderboard` - leaderboard under load
+- `/ws/game` - WebSocket game connections with movement inputs
+
+## Thresholds
+
+| Metric | Threshold |
+|--------|-----------|
+| HTTP error rate | < 5% |
+| HTTP p95 latency | < 2s |
+| WS connection p95 | < 3s |
+| Login error rate | < 5% |
+
+## Running
+
+```bash
+# install k6: https://k6.io/docs/get-started/installation/
+
+# against local stack
+k6 run docs/load-test/load-test.js
+
+# against prod
+k6 run -e BASE_URL=https://conquerio.riveer.cz -e WS_URL=wss://conquerio.riveer.cz docs/load-test/load-test.js
+```
+
+## Load profile
+
+- Ramp up to 20 VUs over 30s
+- Hold at 50 VUs for 1 minute
+- Ramp down over 30s

--- a/docs/load-test/load-test.js
+++ b/docs/load-test/load-test.js
@@ -1,0 +1,105 @@
+import http from "k6/http";
+import ws from "k6/ws";
+import { check, sleep } from "k6";
+import { Rate, Trend } from "k6/metrics";
+
+const BASE_URL = __ENV.BASE_URL || "http://localhost:8080";
+const WS_URL = __ENV.WS_URL || "ws://localhost:8080";
+
+const loginErrors = new Rate("login_errors");
+const wsConnectTime = new Trend("ws_connect_time", true);
+
+// stages: ramp up to 50 concurrent users, hold, ramp down
+export const options = {
+  stages: [
+    { duration: "30s", target: 20 },
+    { duration: "1m",  target: 50 },
+    { duration: "30s", target: 0 },
+  ],
+  thresholds: {
+    http_req_failed:        ["rate<0.05"],   // less than 5% HTTP errors
+    http_req_duration:      ["p(95)<2000"],  // 95% of requests under 2s
+    login_errors:           ["rate<0.05"],
+    ws_connect_time:        ["p(95)<3000"],  // 95% of WS connections under 3s
+  },
+};
+
+// shared pool of pre-registered test accounts
+// run setup() once to create them, then reuse across VUs
+const TEST_PASSWORD = "loadtest1";
+
+export function setup() {
+  const users = [];
+  for (let i = 0; i < 60; i++) {
+    const username = `loadtest_${Date.now()}_${i}`;
+    const email = `${username}@test.invalid`;
+
+    const res = http.post(
+      `${BASE_URL}/api/auth/register`,
+      JSON.stringify({ username, email, password: TEST_PASSWORD }),
+      { headers: { "Content-Type": "application/json" } }
+    );
+
+    if (res.status === 200) {
+      const loginRes = http.post(
+        `${BASE_URL}/api/auth/login`,
+        JSON.stringify({ username, password: TEST_PASSWORD }),
+        { headers: { "Content-Type": "application/json" } }
+      );
+      if (loginRes.status === 200) {
+        users.push({ username, token: loginRes.json("token") });
+      }
+    }
+  }
+  return { users };
+}
+
+export default function (data) {
+  const user = data.users[__VU % data.users.length];
+
+  // --- HTTP: health check ---
+  const health = http.get(`${BASE_URL}/api/health`);
+  check(health, { "health ok": (r) => r.status === 200 });
+
+  // --- HTTP: list rooms ---
+  const rooms = http.get(`${BASE_URL}/api/rooms`, {
+    headers: { Authorization: `Bearer ${user.token}` },
+  });
+  check(rooms, { "rooms ok": (r) => r.status === 200 });
+
+  // --- HTTP: leaderboard ---
+  const lb = http.get(`${BASE_URL}/api/leaderboard`);
+  check(lb, { "leaderboard ok": (r) => r.status === 200 });
+
+  // --- WebSocket: connect to game and send a few moves ---
+  const start = Date.now();
+  const wsRes = ws.connect(
+    `${WS_URL}/ws/game?token=${user.token}`,
+    {},
+    function (socket) {
+      wsConnectTime.add(Date.now() - start);
+
+      socket.on("open", () => {
+        // send a few direction inputs
+        const dirs = ["up", "right", "down", "left"];
+        let i = 0;
+        const interval = socket.setInterval(() => {
+          socket.send(JSON.stringify({ type: "input", direction: dirs[i % 4] }));
+          i++;
+          if (i >= 8) {
+            socket.clearInterval(interval);
+            socket.close();
+          }
+        }, 200);
+      });
+
+      socket.on("error", (e) => {
+        console.error(`ws error for ${user.username}: ${e}`);
+      });
+    }
+  );
+
+  check(wsRes, { "ws connected": (r) => r && r.status === 101 });
+
+  sleep(1);
+}


### PR DESCRIPTION
closes #147

Adds `docs/load-test/load-test.js` - a k6 script that:
- registers 60 test users in setup()
- ramps up to 50 concurrent VUs
- hits health, rooms, leaderboard over HTTP
- connects each VU via WebSocket and sends movement inputs
- fails if >5% errors or p95 latency >2s

Run with: `k6 run docs/load-test/load-test.js`